### PR TITLE
Update Runtime dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,12 +2,21 @@
   "object": {
     "pins": [
       {
+        "package": "CRuntime",
+        "repositoryURL": "https://github.com/wickwirew/CRuntime.git",
+        "state": {
+          "branch": null,
+          "revision": "8d0dd0ca3787d15682c1f44de3d298459870b121",
+          "version": "1.0.0"
+        }
+      },
+      {
         "package": "Runtime",
         "repositoryURL": "https://github.com/wickwirew/Runtime",
         "state": {
-          "branch": "swift42",
-          "revision": "25f7d50212a81b572e9bf5eaa03980945e93898f",
-          "version": null
+          "branch": null,
+          "revision": "40cdfbad9650512507c060824e1c4e9fc2ca721d",
+          "version": "1.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,8 @@ let package = Package(
 		.library(name: "RuntimeExtensions", targets: ["RuntimeExtensions"])
 	],
 	dependencies: [
-		.package(url: "https://github.com/wickwirew/Runtime",  .branch("swift42")),
-		.package(url: "https://github.com/Appsaurus/SwiftTestUtils",  .upToNextMajor(from: "1.0.0"))
+		.package(url: "https://github.com/wickwirew/Runtime", from: "1.1.0"),
+		.package(url: "https://github.com/Appsaurus/SwiftTestUtils", .upToNextMajor(from: "1.0.0"))
 	],
 	targets: [
 		.target(name: "RuntimeExtensions", dependencies: ["Runtime"], path: "Sources/Shared"),


### PR DESCRIPTION
Hi! Currently using `RuntimeExtensions` as a dependency causes `swift package update` to fail with:

```sh
error: the package runtimeextensions[https://github.com/Appsaurus/RuntimeExtensions] @ 0.1.2 contains incompatible dependencies:
    runtime[https://github.com/wickwirew/Runtime] @ swift42
```

Moving to the release versions of Runtime, which also support Swift 4.2, fixes this for me.